### PR TITLE
PR #7: Edits to auth.js in to resolve connection errors when authenticating/registering

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -57,9 +57,9 @@ export default (FacebookStrategy, GoogleStrategy, rethinkdb, appconfig, passport
                 })    
               })
             })
-            /*.catch(err => {
+            .catch(err => {
               console.log('Error Getting User', err)
-            })*/
+            })
           }
         }
       


### PR DESCRIPTION
Rethink connections did not appear to be available for getting or creating users during authentication.

Exposed rethink connections like in the other routes, also moved a return block to send a newUser after creation.